### PR TITLE
Fix issue with cross-origin frames

### DIFF
--- a/src/UI Scripts/snd_xplore_ui.js
+++ b/src/UI Scripts/snd_xplore_ui.js
@@ -634,8 +634,12 @@ $(function () {
       var target = $('#target');
       target.append('<option value="opener">Opener</option>');
       for (var i = 0; frames.length > i; i++) {
-        if (!frames[i].name) continue;
-        target.append('<option value="frame_' + i + '">Opener: ' + frames[i].name + '</option>');
+        var name;
+        try {
+          name = frames[i].name;
+        } catch (e) {} // ignore cross-origin frame SecurityErrors
+        if (!name) continue;
+        target.append('<option value="frame_' + i + '">Opener: ' + name + '</option>');
       }
     }
   })();


### PR DESCRIPTION
Thanks so much for sharing this awesome tool! After installing the update set, and launching Xplore, I encountered an unhandled (client) JavaScript SecurityError which prevented the page from completely loading. The loop that builds up your frame selector blew up on a cross-origin frame (inserted by a chrome extension I use). This pull request ignores the errors if you end up iterating over a cross-origin frame.